### PR TITLE
Bump beta version to latest

### DIFF
--- a/manifests/beta.pp
+++ b/manifests/beta.pp
@@ -4,7 +4,7 @@
 #
 #   include tunnelblick::beta
 class tunnelblick::beta {
-  $version = '3.4beta20'
+  $version = '3.4beta22'
 
   package { 'Tunnelblick':
     provider => 'appdmg',

--- a/spec/classes/tunnelblick_spec.rb
+++ b/spec/classes/tunnelblick_spec.rb
@@ -13,7 +13,7 @@ describe 'tunnelblick::beta' do
   it do
     should contain_package('Tunnelblick').with({
       :provider => 'appdmg',
-      :source   => 'http://downloads.sourceforge.net/project/tunnelblick/All%20files/Tunnelblick_3.4beta20.dmg',
+      :source   => 'http://downloads.sourceforge.net/project/tunnelblick/All%20files/Tunnelblick_3.4beta22.dmg',
     })
   end
 end


### PR DESCRIPTION
Bumps beta to latest version that includes OpenSSL library version 1.0.1g, which does not have the "heartbeat" vulnerability.

https://code.google.com/p/tunnelblick/wiki/RlsNotes
